### PR TITLE
allow docker container to build on m1

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,5 +1,5 @@
 # https://pipenv.pypa.io/en/latest/basics/#pipenv-and-docker-containers
-FROM docker.io/python:3.10 AS base
+FROM --platform=linux/amd64 docker.io/python:3.10 AS base
 
 RUN apt update && \
     apt install -y python3-dev libpq-dev


### PR DESCRIPTION
There were issues building the docker container on m1 macs. This should provide a fix for that