### PR TITLE
fix(infra): move environment flag after runner

### DIFF
--- a/.github/workflows/ci-staging.yml
+++ b/.github/workflows/ci-staging.yml
@@ -129,9 +129,9 @@ jobs:
       dockerTag: ${{ steps.vars.outputs.sha_short }}
 
   deploy-staging:
-    environment: Staging
     needs: [test, build-api, build-verifier]
     runs-on: ubuntu-latest
+    environment: Staging
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js


### PR DESCRIPTION
Move environment flag after runner, because environment can only be set after runner is set https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#using-an-environment

` The job can access the environment's secrets only after the job is sent to a runner.`