### PR TITLE
feat(api,ratelimit,infra): adjusting the infra deployment, to take th…

### DIFF
--- a/infra/prod/index.ts
+++ b/infra/prod/index.ts
@@ -346,6 +346,10 @@ const secrets = [
     name: "GOOGLE_CLIENT_SECRET",
     valueFrom: `${SCORER_SERVER_SSM_ARN}:GOOGLE_CLIENT_SECRET::`,
   },
+  {
+    name: "RATELIMIT_ENABLE",
+    valueFrom: `${SCORER_SERVER_SSM_ARN}:RATELIMIT_ENABLE::`,
+  },
 ];
 const environment = [
   {

--- a/infra/review/index.ts
+++ b/infra/review/index.ts
@@ -292,6 +292,10 @@ const secrets = [
     name: "GOOGLE_CLIENT_SECRET",
     valueFrom: `${SCORER_SERVER_SSM_ARN}:GOOGLE_CLIENT_SECRET::`,
   },
+  {
+    name: "RATELIMIT_ENABLE",
+    valueFrom: `${SCORER_SERVER_SSM_ARN}:RATELIMIT_ENABLE::`,
+  },
 ];
 const environment = [
   {
@@ -304,7 +308,10 @@ const environment = [
   },
   {
     name: "UI_DOMAINS",
-    value: JSON.stringify(["scorer." + process.env["DOMAIN"], "www.scorer." + process.env["DOMAIN"]]),
+    value: JSON.stringify([
+      "scorer." + process.env["DOMAIN"],
+      "www.scorer." + process.env["DOMAIN"],
+    ]),
   },
   {
     name: "ALLOWED_HOSTS",

--- a/infra/staging/index.ts
+++ b/infra/staging/index.ts
@@ -292,6 +292,10 @@ const secrets = [
     name: "GOOGLE_CLIENT_SECRET",
     valueFrom: `${SCORER_SERVER_SSM_ARN}:GOOGLE_CLIENT_SECRET::`,
   },
+  {
+    name: "RATELIMIT_ENABLE",
+    valueFrom: `${SCORER_SERVER_SSM_ARN}:RATELIMIT_ENABLE::`,
+  },
 ];
 const environment = [
   {


### PR DESCRIPTION
feat(api,ratelimit,infra): adjusting the infra deployment, to take the RATELIMIT_ENABLE flag from secrets

This also fixes: https://github.com/gitcoinco/passport-scorer/issues/28
(it adds the required infra part).