### PR TITLE
fix(api,rate-limit): fixing rate limit issues

### DIFF
--- a/api/registry/api.py
+++ b/api/registry/api.py
@@ -112,7 +112,7 @@ def check_rate_limit(request):
         request=request,
         group="registry",
         fn=None,
-        key="header:x-api-key",
+        key=lambda _request, _group: request.api_key.prefix,
         rate=rate,
         method=ALL,
         increment=True,

--- a/api/registry/test/test_ratelimit.py
+++ b/api/registry/test/test_ratelimit.py
@@ -11,8 +11,41 @@ log = logging.getLogger(__name__)
 
 
 @override_settings(RATELIMIT_ENABLE=True)
-def test_rate_limit_is_applyed(scorer_api_key):
-    """Make sure the rate limit set in the account is applied when calling the APIs"""
+def test_rate_limit_from_db_is_applied_for_api_key(scorer_api_key):
+    """
+    Make sure the rate limit set in the account is applied when calling the APIs
+    When using the x-api-key header
+    """
+
+    client = Client()
+    # The lowest default limit is set to 125/15m, so we expect to be able to make
+    # 125 successfull calls, and then get a 429 error
+    for _ in range(125):
+        response = client.get(
+            "/registry/signing-message",
+            # HTTP_X_API_KEY must spelled exactly as this because it
+            # will not be converted to HTTP_X_API_KEY by Django Test Client
+            **{"HTTP_X_API_KEY": scorer_api_key},
+        )
+
+        assert response.status_code == 200
+
+    response = client.get(
+        "/registry/signing-message",
+        # HTTP_X_API_KEY must spelled exactly as this because it
+        # will not be converted to HTTP_X_API_KEY by Django Test Client
+        **{"HTTP_X_API_KEY": scorer_api_key},
+    )
+
+    assert response.status_code == 429
+
+
+@override_settings(RATELIMIT_ENABLE=True)
+def test_rate_limit_from_db_is_applied_for_token(scorer_api_key):
+    """
+    Make sure the rate limit set in the account is applied when calling the APIs
+    When using the HTTP_AUTHORIZATION header
+    """
 
     client = Client()
     # The lowest default limit is set to 125/15m, so we expect to be able to make

--- a/api/scorer/settings/base.py
+++ b/api/scorer/settings/base.py
@@ -224,7 +224,7 @@ LOGGING = {
         },
         "django.db.backends": {
             "level": "DEBUG",
-            "handlers": ["debugConsole"],
+            "handlers": [],
             "propagate": False,
         },
     },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,21 +15,28 @@ services:
     volumes:
       - ./api:/app
 
+    environment:
+      - CELERY_BROKER_URL=redis://redis:6379/0
+      - CERAMIC_CACHE_CACAO_VALIDATION_URL=http://verifier:8001/verify
+
     command: uvicorn scorer.asgi:application --reload --host 0.0.0.0 --port 8002
 
-  # worker:
-  #   build: api
+  worker:
+    build: api
 
-  #   volumes:
-  #     - ./api:/app
+    volumes:
+      - ./api:/app
 
-  #   command: celery -A scorer worker -l DEBUG
+    environment:
+      - CELERY_BROKER_URL=redis://redis:6379/0
+
+    command: celery -A scorer worker -l DEBUG
 
   interface:
     build: interface
 
     ports:
-      - "127.0.0.1:3000:3000"
+      - "127.0.0.1:3001:3000"
 
   verifier:
     build: verifier


### PR DESCRIPTION

- make ratelimit work the same regardless if the api key was passed in the AUTHORIZATION header or API-Key
- have created tests explicitly with api-key and authorization header
- adjusted the docker-compose
- disable logs for 'django.db.backends'

This closes: https://github.com/gitcoinco/passport/issues/1038