### PR TITLE
feat(api): score calculations should also be run if requires_calculat…

### DIFF
--- a/api/registry/test/test_score_passport.py
+++ b/api/registry/test/test_score_passport.py
@@ -201,7 +201,7 @@ class TestScorePassportTestCase(TransactionTestCase):
                     score_passport_passport(self.community.pk, self.account.address)
 
                     expected_call = call(
-                        "Passport no passport found for address='%s', community_id='%s' that has requires_calculation=True",
+                        "Passport no passport found for address='%s', community_id='%s' that has requires_calculation=True or None",
                         self.account.address,
                         self.community.pk,
                     )


### PR DESCRIPTION
…ion is None, as this will be the default value

This fixes: https://github.com/gitcoinco/passport/issues/1329

This fix enables running the calculations when `requires_calculation` is `None/null`.
`None/null` will be the default when we enable this feature and run the migrations, and we don't want the existing tasks from the queues to be skipped by default in this case.