### PR TITLE
feat(api): add scoring weight for ZkSyncEra credential

### DIFF
--- a/api/scorer/settings/gitcoin_passport_weights.py
+++ b/api/scorer/settings/gitcoin_passport_weights.py
@@ -62,7 +62,8 @@ GITCOIN_PASSPORT_WEIGHTS = {
     "TwitterFollowerGT5000": "0",
     "TwitterFollowerGTE1000": "1.77",
     "TwitterTweetGT10": "1.67",
-    "ZkSync": "1.67",
+    "ZkSync": "0.835",
+    "ZkSyncEra": "0.835",
 }
 
 


### PR DESCRIPTION
closes https://github.com/gitcoinco/passport/issues/1374