### PR TITLE
first pass at new stamp PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/stamp_pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/stamp_pull_request_template.md
@@ -1,0 +1,52 @@
+<!--
+Instructions:
+
+Hello! Thank you for taking the time to propose a stamp for the Passport app.
+We're excited to work with you on reviewing your stamp. Please fill out the
+following information. Failure to do so will result in delays reviewing your
+stamp or we may reject your proposal entirely.
+
+You'll find a series of questions and fields below containing information we
+need from you to properly review your stamp. Any text surrounded by angle
+brackets (<>) should be replaced with the appropriate information about your
+project. Headings should be followed by a few sentences that answer the question
+or explain the topic.
+
+When you finish, please fill out this Google form: https://forms.gle/29aqP3shRivRR6Bo6
+
+-->
+# <Stamp Provider>
+<!--
+Replace this comment with a brief (1-3 sentences) paragraph explaining your
+project.
+-->
+
+## Meta Data
+
+Project Name: <project name>
+
+Website: <https://www.project.com>
+
+Daily Active Users (DAUs): <420,000>
+
+Stamp name: <stamp name>
+
+## Data and Credentials
+
+<!--
+For a stamp to be usefull, it should include a couple of credentials. For
+each verifiable credential you issue as part of your stamp, please provide:
+
+- the vc name (i.e. `gtcPosessionsGte#10`)
+- the data point in your app that supports this VC (i.e. )
+- difficulty to achieve (based on % of your users who qualify): <easy|medium|hard>
+
+-->
+
+## Reasoning
+
+<!--
+We're looking for data (and ultimately VCs) that can help us detect and prevent
+bots. Please share a few sentences here that outline how the data provided by
+your stamp will help us do that.
+-->


### PR DESCRIPTION
This PR creates a template for future pull requests where someone is trying to
add a stamp to Passport. The idea is that they would submit their stamp using
this PR template and follow it up by submitting the attached Google form.

In addition to the instructions in this PR template and the attached Google
form, we're working on adding a page to the documentation that outlines the
steps and what we're looking for from stamp providers.
