### PR TITLE
fix(infra): increase max storage on read replica to match main instance

### DIFF
--- a/infra/prod/index.ts
+++ b/infra/prod/index.ts
@@ -98,7 +98,7 @@ const readreplica0 = new aws.rds.Instance(
   `scorer-db-read-0`,
   {
     allocatedStorage: 20,
-    maxAllocatedStorage: 100,
+    maxAllocatedStorage: 500,
     instanceClass: "db.t3.xlarge",
     skipFinalSnapshot: true,
     vpcSecurityGroupIds: [db_secgrp.id],


### PR DESCRIPTION
Match the max storage of the primary db instance 