### PR TITLE
fix(infra,api): making  optional in the scorer_dump_data command, als…

### DIFF
--- a/api/ceramic_cache/management/commands/scorer_dump_data.py
+++ b/api/ceramic_cache/management/commands/scorer_dump_data.py
@@ -324,7 +324,7 @@ class Command(BaseCommand):
                         file_name,
                         s3_bucket_name,
                         s3_key,
-                        ExtraArgs=model_config["extra-args"],
+                        ExtraArgs=model_config.get("extra-args", {}),
                     )
                     model_summary["finished_at"] = datetime.datetime.now().isoformat()
                     model_summary["s3_key"] = s3_key

--- a/infra/prod/index.ts
+++ b/infra/prod/index.ts
@@ -1072,10 +1072,14 @@ export const dailyDataDumpTaskDefinition = createScheduledTask(
       "scorer_dump_data",
       "--config",
       JSON.stringify([
-        { name: "ceramic_cache.CeramicCache" },
-        { name: "registry.Event" },
-        { name: "registry.HashScorerLink" },
-        { name: "registry.Stamp", select_related: ["passport"] },
+        { name: "ceramic_cache.CeramicCache", "extra-args": {} },
+        { name: "registry.Event", "extra-args": {} },
+        { name: "registry.HashScorerLink", "extra-args": {} },
+        {
+          name: "registry.Stamp",
+          select_related: ["passport"],
+          "extra-args": {},
+        },
       ]),
       "--s3-uri=s3://passport-scorer/daily_data_dumps/",
       "--batch-size=20000",


### PR DESCRIPTION
…o passing in default extra-args as {} in the scheduled task

This fixes: https://github.com/gitcoinco/passport/issues/1644
