### PR TITLE
feat(infra): scale down staging & review

### DIFF
--- a/infra/prod/index.ts
+++ b/infra/prod/index.ts
@@ -536,8 +536,8 @@ const baseScorerServiceConfig: ScorerService = {
   needsVerifier: false,
   httpListenerArn: httpsListener.arn,
   targetGroup: targetGroupDefault,
-  autoScaleMaxCapacity: 2,
-  autoScaleMinCapacity: 1,
+  autoScaleMaxCapacity: 20,
+  autoScaleMinCapacity: 2,
   alertTopic: pagerdutyTopic,
 };
 
@@ -737,7 +737,7 @@ const celery2 = new awsx.ecs.FargateService("scorer-bkgrnd-worker-passport", {
           "16",
         ],
         memory: 2048,
-        cpu: 1000,
+        cpu: 1024,
         portMappings: [],
         secrets: secrets,
         environment: environment,
@@ -751,7 +751,7 @@ const celery2 = new awsx.ecs.FargateService("scorer-bkgrnd-worker-passport", {
 const ecsScorerWorker2AutoscalingTarget = new aws.appautoscaling.Target(
   "scorer-worker2-autoscaling-target",
   {
-    maxCapacity: 400,
+    maxCapacity: 20,
     minCapacity: 2,
     resourceId: pulumi.interpolate`service/${cluster.name}/${celery2.service.name}`,
     scalableDimension: "ecs:service:DesiredCount",
@@ -1279,8 +1279,8 @@ export const dailyDataDumpTaskDefinition = createScheduledTask(
   "daily-data-dump",
   {
     ...baseScorerServiceConfig,
-    cpu: 4,
-    memory: 8192,
+    cpu: 1024,
+    memory: 2048,
     securityGroup: secgrp,
     ephemeralStorageSizeInGiB: 100,
     command: [

--- a/infra/review/index.ts
+++ b/infra/review/index.ts
@@ -691,8 +691,8 @@ const celery2 = new awsx.ecs.FargateService("scorer-bkgrnd-worker-passport", {
           "-l",
           "DEBUG",
         ],
-        memory: 4096,
-        cpu: 2000,
+        memory: 1024,
+        cpu: 1024,
         portMappings: [],
         secrets: secrets,
         environment: environment,
@@ -805,7 +805,7 @@ echo $(date) "Finished installation of docker" >> /var/log/gitcoin/init.log
 const web = new aws.ec2.Instance("Web", {
   ami: ubuntu.then((ubuntu) => ubuntu.id),
   associatePublicIpAddress: true,
-  instanceType: "t3.medium",
+  instanceType: "t3.small",
   subnetId: vpcPublicSubnetId1,
   vpcSecurityGroupIds: [secgrp.id],
   rootBlockDevice: {

--- a/infra/staging/index.ts
+++ b/infra/staging/index.ts
@@ -411,7 +411,7 @@ const baseScorerServiceConfig: ScorerService = {
   autoScaleMinCapacity: 1,
   autoScaleMaxCapacity: 2,
   cpu: 512,
-  memory: 512,
+  memory: 1024,
 };
 
 const scorerServiceDefault = createScorerECSService(


### PR DESCRIPTION
- things to note: cpu, memory, autoscaling min & max can now be specified in the createScorerECSService
- also cpu & memory, both should take values that are powers of 2
- also adding tags to some of the resources, should help tracking prices

Fixes: https://github.com/gitcoinco/passport/issues/1708


