### PR TITLE
fix(api): handle base64 encoded body in lambda

### DIFF
--- a/api/aws_lambdas/submit_passport/submit_passport.py
+++ b/api/aws_lambdas/submit_passport/submit_passport.py
@@ -2,6 +2,7 @@
 This module provides a handler to manage API requests in AWS Lambda.
 """
 
+import base64
 import logging
 import os
 
@@ -60,7 +61,11 @@ def handler(event, _context):
         # rate limit
         check_rate_limit(request)
 
-        body = json.loads(event["body"])
+        if event["isBase64Encoded"]:
+            body = json.loads(base64.b64decode(event["body"]).decode("utf-8"))
+        else:
+            body = json.loads(event["body"])
+
         if user_account:
             score = async_to_sync(ahandle_submit_passport)(
                 SubmitPassportPayload(**body), user_account

--- a/api/aws_lambdas/submit_passport/tests/test_submit_passport_lambda.py
+++ b/api/aws_lambdas/submit_passport/tests/test_submit_passport_lambda.py
@@ -1,3 +1,4 @@
+import base64
 import json
 
 import pytest
@@ -43,6 +44,37 @@ def make_test_event(api_key, address, community_id):
     }
 
 
+def make_test_event_with_base64_encoded_body(api_key, address, community_id):
+    """
+    Creates a mock event for testing purposes.
+    """
+    return {
+        "requestContext": {
+            "elb": {
+                "targetGroupArn": "arn:aws:elasticloadbalancing:us-west-2:515520736917:targetgroup/testTargetGroup-e050da0/c8f86571a77b9bc5"
+            }
+        },
+        "httpMethod": "POST",
+        "path": "/registry/submit-passport",
+        "queryStringParameters": {},
+        "headers": {
+            "content-length": "73",
+            "content-type": "application/json",
+            "host": "api.staging.scorer.gitcoin.co",
+            "user-agent": "k6/0.46.0 (https://k6.io/)",
+            "x-amzn-trace-id": "Root=1-650373d8-19455f7f1bfd3c6f0fc3f323",
+            "x-api-key": api_key,
+            "x-forwarded-for": "164.90.200.92",
+            "x-forwarded-port": "443",
+            "x-forwarded-proto": "https",
+        },
+        "body": base64.b64encode(
+            json.dumps({"address": address, "community": community_id}).encode("utf-8")
+        ),
+        "isBase64Encoded": True,
+    }
+
+
 def test_successful_authentication(
     scorer_api_key,
     scorer_community_with_binary_scorer,
@@ -62,6 +94,51 @@ def test_successful_authentication(
         ):
             address = passport_holder_addresses[0]["address"].lower()
             event = make_test_event(
+                scorer_api_key, address, scorer_community_with_binary_scorer.id
+            )
+
+            response = handler(event, None)
+
+            assert response is not None
+            body = json.loads(response["body"])
+
+            assert body["address"] == address
+            assert body["score"] == "0"
+            assert body["status"] == "DONE"
+            assert body["evidence"] == {
+                "type": "ThresholdScoreCheck",
+                "success": False,
+                "rawScore": 2,
+                "threshold": 75.0,
+            }
+            assert body["error"] is None
+            assert body["stamp_scores"] == {"Ens": 1.0, "Google": 1.0}
+            # We just check that something != None was recorded for the last timestamp
+            assert body["last_score_timestamp"] is not None
+
+            assert response["statusCode"] == 200
+
+
+def test_successful_authentication_and_base64_encoded_body(
+    scorer_api_key,
+    scorer_community_with_binary_scorer,
+    passport_holder_addresses,
+    mocker,
+):
+    """
+    Tests that authentication is successful given correct credentials.
+    Also this test uses a body payload that is base64 encoded.
+    """
+
+    with mocker.patch(
+        "registry.atasks.aget_passport",
+        return_value=mock_passport,
+    ):
+        with mocker.patch(
+            "registry.atasks.validate_credential", side_effect=[[], [], []]
+        ):
+            address = passport_holder_addresses[0]["address"].lower()
+            event = make_test_event_with_base64_encoded_body(
                 scorer_api_key, address, scorer_community_with_binary_scorer.id
             )
 


### PR DESCRIPTION

Fixes: https://github.com/gitcoinco/passport-scorer/issues/424
