### PR TITLE
chore(api): remove facebook stamp

### DIFF
--- a/api/aws_lambdas/scorer_api_passport/tests/test_bulk_stamp_lambdas.py
+++ b/api/aws_lambdas/scorer_api_passport/tests/test_bulk_stamp_lambdas.py
@@ -21,7 +21,7 @@ def test_patch(
         "body": json.dumps(
             [
                 good_stamp,
-                {"provider": "Facebook"},
+                {"provider": "Ens"},
             ]
         ),
         "isBase64Encoded": False,

--- a/api/aws_lambdas/scorer_api_passport/tests/test_bulk_stamp_lambdas_v2.py
+++ b/api/aws_lambdas/scorer_api_passport/tests/test_bulk_stamp_lambdas_v2.py
@@ -21,7 +21,7 @@ def test_patch(
         "body": json.dumps(
             [
                 good_stamp,
-                {"provider": "Facebook"},
+                {"provider": "Ens"},
             ]
         ),
         "isBase64Encoded": False,

--- a/api/registry/test/test_command_recalculate_scores.py
+++ b/api/registry/test/test_command_recalculate_scores.py
@@ -22,7 +22,7 @@ def fixture_binaty_weighted_scorer_passports(
     )
     Stamp.objects.create(
         passport=passport,
-        provider="Facebook",
+        provider="FirstEthTxnProvider",
         hash="0x1234",
         credential={},
     )
@@ -34,7 +34,7 @@ def fixture_binaty_weighted_scorer_passports(
 
     Stamp.objects.create(
         passport=passport1,
-        provider="Facebook",
+        provider="FirstEthTxnProvider",
         hash="0x12345",
         credential={},
     )
@@ -52,7 +52,7 @@ def fixture_binaty_weighted_scorer_passports(
 
     Stamp.objects.create(
         passport=passport2,
-        provider="Facebook",
+        provider="FirstEthTxnProvider",
         hash="0x12345a",
         credential={},
     )
@@ -82,7 +82,7 @@ def fixture_weighted_scorer_passports(
     )
     Stamp.objects.create(
         passport=passport,
-        provider="Facebook",
+        provider="FirstEthTxnProvider",
         hash="0x1234",
         credential={},
     )
@@ -94,7 +94,7 @@ def fixture_weighted_scorer_passports(
 
     Stamp.objects.create(
         passport=passport1,
-        provider="Facebook",
+        provider="FirstEthTxnProvider",
         hash="0x12345",
         credential={},
     )
@@ -112,7 +112,7 @@ def fixture_weighted_scorer_passports(
 
     Stamp.objects.create(
         passport=passport2,
-        provider="Facebook",
+        provider="FirstEthTxnProvider",
         hash="0x12345a",
         credential={},
     )
@@ -164,7 +164,7 @@ class TestRecalculatScores:
             assert s.error == None
 
     updated_weights = {
-        "Facebook": "75",
+        "FirstEthTxnProvider": "75",
         "Google": "1",
         "Ens": "1",
     }
@@ -201,18 +201,18 @@ class TestRecalculatScores:
         s1 = Score.objects.get(passport=binary_weighted_scorer_passports[0])
         assert s1.evidence["rawScore"] == "75"
         assert len(s1.stamp_scores) == 1
-        assert "Facebook" in s1.stamp_scores
+        assert "FirstEthTxnProvider" in s1.stamp_scores
 
         s2 = Score.objects.get(passport=binary_weighted_scorer_passports[1])
         assert s2.evidence["rawScore"] == "76"
         assert len(s2.stamp_scores) == 2
-        assert "Facebook" in s2.stamp_scores
+        assert "FirstEthTxnProvider" in s2.stamp_scores
         assert "Google" in s2.stamp_scores
 
         s3 = Score.objects.get(passport=binary_weighted_scorer_passports[2])
         assert s3.evidence["rawScore"] == "77"
         assert len(s3.stamp_scores) == 3
-        assert "Facebook" in s3.stamp_scores
+        assert "FirstEthTxnProvider" in s3.stamp_scores
         assert "Google" in s3.stamp_scores
         assert "Ens" in s3.stamp_scores
 
@@ -247,23 +247,23 @@ class TestRecalculatScores:
         s1 = Score.objects.get(passport=weighted_scorer_passports[0])
         assert s1.score == 1
         assert len(s1.stamp_scores) == 1
-        assert "Facebook" in s1.stamp_scores
+        assert "FirstEthTxnProvider" in s1.stamp_scores
 
         s2 = Score.objects.get(passport=weighted_scorer_passports[1])
         assert s2.score == 2
         assert len(s2.stamp_scores) == 2
-        assert "Facebook" in s2.stamp_scores
+        assert "FirstEthTxnProvider" in s2.stamp_scores
         assert "Google" in s2.stamp_scores
 
         s3 = Score.objects.get(passport=weighted_scorer_passports[2])
         assert s3.score == 3
         assert len(s3.stamp_scores) == 3
-        assert "Facebook" in s3.stamp_scores
+        assert "FirstEthTxnProvider" in s3.stamp_scores
         assert "Google" in s3.stamp_scores
         assert "Ens" in s3.stamp_scores
 
     updated_weights = {
-        "Facebook": "75",
+        "FirstEthTxnProvider": "75",
         "Google": "1",
         "Ens": "1",
     }
@@ -287,7 +287,7 @@ class TestRecalculatScores:
         # Check the initial threshold
         assert len(scores) == 0
         call_command("recalculate_scores", *args, **opts)
-        scorer.weights["Facebook"] = 75
+        scorer.weights["FirstEthTxnProvider"] = 75
         scorer.save()
 
         call_command("recalculate_scores", *args, **opts)
@@ -304,18 +304,18 @@ class TestRecalculatScores:
         s1 = Score.objects.get(passport=weighted_scorer_passports[0])
         assert s1.score == 75
         assert len(s1.stamp_scores) == 1
-        assert "Facebook" in s1.stamp_scores
+        assert "FirstEthTxnProvider" in s1.stamp_scores
 
         s2 = Score.objects.get(passport=weighted_scorer_passports[1])
         assert s2.score == 76
         assert len(s2.stamp_scores) == 2
-        assert "Facebook" in s2.stamp_scores
+        assert "FirstEthTxnProvider" in s2.stamp_scores
         assert "Google" in s2.stamp_scores
 
         s3 = Score.objects.get(passport=weighted_scorer_passports[2])
         assert s3.score == 77
         assert len(s3.stamp_scores) == 3
-        assert "Facebook" in s3.stamp_scores
+        assert "FirstEthTxnProvider" in s3.stamp_scores
         assert "Google" in s3.stamp_scores
         assert "Ens" in s3.stamp_scores
 

--- a/api/scorer/settings/gitcoin_passport_weights.py
+++ b/api/scorer/settings/gitcoin_passport_weights.py
@@ -17,8 +17,6 @@ GITCOIN_PASSPORT_WEIGHTS = {
     "ethPossessionsGte#1": "3.12",
     "ethPossessionsGte#10": "1.27",
     "ethPossessionsGte#32": "1.27",
-    "Facebook": "0.689",
-    "FacebookProfilePicture": "0.689",
     "FirstEthTxnProvider": "1.16",
     "GitcoinContributorStatistics#numGrantsContributeToGte#1": "2.91",
     "GitcoinContributorStatistics#numGrantsContributeToGte#10": "3.64",

--- a/api/scorer/test/conftest.py
+++ b/api/scorer/test/conftest.py
@@ -82,7 +82,7 @@ def scorer_api_key_no_permissions(scorer_account):
 
 @pytest.fixture
 def scorer_community_with_binary_scorer(mocker, scorer_account):
-    mock_settings = {"Facebook": 1, "Google": 1, "Ens": 1}
+    mock_settings = {"FirstEthTxnProvider": 1, "Google": 1, "Ens": 1}
     # Mock gitcoin scoring settings
     mocker.patch(
         "scorer_weighted.models.settings.GITCOIN_PASSPORT_WEIGHTS",
@@ -111,7 +111,7 @@ def ui_scorer(scorer_community_with_binary_scorer):
 
 @pytest.fixture
 def scorer_community_with_weighted_scorer(mocker, scorer_account):
-    mock_settings = {"Facebook": 1, "Google": 1, "Ens": 1}
+    mock_settings = {"FirstEthTxnProvider": 1, "Google": 1, "Ens": 1}
     # Mock gitcoin scoring settings
     mocker.patch(
         "scorer_weighted.models.settings.GITCOIN_PASSPORT_WEIGHTS",

--- a/api/scorer_weighted/tests/test_binary_weighted_scorer.py
+++ b/api/scorer_weighted/tests/test_binary_weighted_scorer.py
@@ -17,7 +17,7 @@ def fixture_weighted_scorer_passports(
     )
     Stamp.objects.create(
         passport=passport,
-        provider="Facebook",
+        provider="FirstEthTxnProvider",
         hash="0x1234",
         credential={},
     )
@@ -29,7 +29,7 @@ def fixture_weighted_scorer_passports(
 
     Stamp.objects.create(
         passport=passport1,
-        provider="Facebook",
+        provider="FirstEthTxnProvider",
         hash="0x12345",
         credential={},
     )
@@ -47,7 +47,7 @@ def fixture_weighted_scorer_passports(
 
     Stamp.objects.create(
         passport=passport2,
-        provider="Facebook",
+        provider="FirstEthTxnProvider",
         hash="0x12345a",
         credential={},
     )
@@ -70,7 +70,7 @@ def fixture_weighted_scorer_passports(
 class TestBinaraWeightedScorer:
     def test_binary_weighted_scorer(self, weighted_scorer_passports):
         scorer = BinaryWeightedScorer(
-            threshold=2, weights={"Facebook": 1, "Google": 1, "Ens": 1}
+            threshold=2, weights={"FirstEthTxnProvider": 1, "Google": 1, "Ens": 1}
         )
         scorer.save()
 
@@ -88,13 +88,13 @@ class TestBinaraWeightedScorer:
 
         Stamp.objects.create(
             passport=weighted_scorer_passports[0],
-            provider="Facebook",
+            provider="FirstEthTxnProvider",
             hash="0x12345",
             credential={},
         )
 
         scorer = BinaryWeightedScorer(
-            threshold=2, weights={"Facebook": 1, "Google": 1, "Ens": 1}
+            threshold=2, weights={"FirstEthTxnProvider": 1, "Google": 1, "Ens": 1}
         )
         scorer.save()
 

--- a/load_tests/test_data/config.py
+++ b/load_tests/test_data/config.py
@@ -9,8 +9,6 @@ providers = [
     "TwitterFollowerGTE1000",
     "TwitterFollowerGT5000",
     "POAP",
-    "Facebook",
-    "FacebookProfilePicture",
     "Brightid",
     "Github",
     "FiveOrMoreGithubRepos",


### PR DESCRIPTION
Fixes: https://github.com/gitcoinco/passport/issues/1991

Will need to run `python manage.py recalculate_scores`

Will need to ensure that Magic scorer weights are not rescored in this process. https://github.com/gitcoinco/passport-scorer/blob/99eeda0654212cf77d2aa14697f8c0a4d9443a98/api/registry/management/commands/recalculate_scores.py#L64