### PR TITLE
fix(infra): remove period config

### DIFF
--- a/infra/lib/scorer/new_service.ts
+++ b/infra/lib/scorer/new_service.ts
@@ -505,7 +505,6 @@ export function createScorerECSService(
          */
         datapointsToAlarm: 8,
         evaluationPeriods: 10,
-        period: 60,
         metricQueries: [
           {
             id: "m1",


### PR DESCRIPTION
Fixes: aws:cloudwatch/metricAlarm:MetricAlarm resource 'HTTP-Target-4XX-scorer-api-default' has a problem: Conflicting configuration arguments: "period": conflicts with metric_query. Examine values at 'HTTP-Target-4XX-scorer-api-default.period'.

