### PR TITLE
feat: adding Outdid stamp to the scorer weights

### DIFF
--- a/api/scorer/settings/gitcoin_passport_weights.py
+++ b/api/scorer/settings/gitcoin_passport_weights.py
@@ -47,6 +47,7 @@ GITCOIN_PASSPORT_WEIGHTS = {
     "zkSyncScore#20": "1.67",
     "zkSyncScore#50": "1.67",
     "zkSyncScore#5": "1.67",
+    "Outdid": "10",
 }
 
 


### PR DESCRIPTION

Fixes: https://github.com/gitcoinco/passport/issues/2601
