### PR TITLE
Update scoring bonus threshold from 3 to 4 passing scores

### DIFF
--- a/api/registry/human_points_utils.py
+++ b/api/registry/human_points_utils.py
@@ -147,7 +147,7 @@ async def arecord_stamp_actions(address: str, valid_stamps: list) -> None:
 
 async def acheck_and_award_scoring_bonus(address: str, community_id: int) -> bool:
     """
-    Check if user qualifies for scoring bonus (3+ passing scores)
+    Check if user qualifies for scoring bonus (4+ passing scores)
     Returns True if bonus was newly awarded
     """
     # Check current passing scores count
@@ -156,7 +156,7 @@ async def acheck_and_award_scoring_bonus(address: str, community_id: int) -> boo
     ).acount()
 
     # Award bonus if qualified (let DB handle conflicts)
-    if qualified_count >= 3:
+    if qualified_count >= 4:
         _, created = await HumanPoints.objects.aget_or_create(
             address=address, action=HumanPoints.Action.SCORING_BONUS
         )


### PR DESCRIPTION
## Summary
Updated the Human Points scoring bonus threshold from 3 to 4 passing scores.

## Changes
- **Function**: `acheck_and_award_scoring_bonus()` now requires 4+ passing scores instead of 3+
- **Test**: Updated `test_scoring_bonus_awarded` to create 4 communities and expect 4 passing scores
- **Documentation**: Updated test docstring and comments to reflect new threshold

## Testing
- [x] Function logic remains the same, only threshold changed
- [x] No breaking changes to existing functionality