### PR TITLE
feat(scorer): increase Biometrics and CleanHands stamp weights

### DIFF
--- a/api/scorer/config/gitcoin_passport_weights.py
+++ b/api/scorer/config/gitcoin_passport_weights.py
@@ -2,12 +2,14 @@
 
 # Weight values for each stamp based on its perceived significance in assessing the unique humanity of the Passport holder
 GITCOIN_PASSPORT_WEIGHTS = {
+    "Biometrics": "6.001",
     "BinanceBABT": "16.021",
     "BinanceBABT2": "10.021",
     "Brightid": "0.202",
     "CivicCaptchaPass": "0.823",
     "CivicLivenessPass": "3.038",
     "CivicUniquenessPass": "5.005",
+    "CleanHands": "3",
     "CoinbaseDualVerification": "16.042",
     "CoinbaseDualVerification2": "10.042",
     "Discord": "0.516",

--- a/api/scorer/settings/gitcoin_passport_weights.py
+++ b/api/scorer/settings/gitcoin_passport_weights.py
@@ -3,12 +3,14 @@
 # Weight values for each stamp based on its perceived significance in assessing the unique humanity of the Passport holder
 GITCOIN_PASSPORT_WEIGHTS = {
     "BeginnerCommunityStaker": "0.673",
+    "Biometrics": "6.001",
     "BinanceBABT": "16.021",
     "BinanceBABT2": "10.021",
     "Brightid": "0.202",
     "CivicCaptchaPass": "0.823",
     "CivicLivenessPass": "3.038",
     "CivicUniquenessPass": "5.005",
+    "CleanHands": "3",
     "CoinbaseDualVerification": "16.042",
     "CoinbaseDualVerification2": "10.042",
     "Discord": "0.516",


### PR DESCRIPTION
## Description
Increases the weights for Biometrics and CleanHands stamps as requested in #3708.

### Changes
- **Biometrics**: Set weight to `6.001`
- **CleanHands**: Set weight to `3`

### Notes
- These changes apply to default weights only
- Custom passport dashboards (Recall, Lido, Shape, Octant) have their own custom weight configurations and will not be affected by these changes

Closes [#3708](https://github.com/passportxyz/passport/issues/3708)