### PR TITLE
feat(scorer): reduce Coinbase stamp weight to 4.042 points

### DIFF
--- a/api/scorer/config/gitcoin_passport_weights.py
+++ b/api/scorer/config/gitcoin_passport_weights.py
@@ -9,7 +9,7 @@ GITCOIN_PASSPORT_WEIGHTS = {
     "CivicLivenessPass": "3.038",
     "CivicUniquenessPass": "5.005",
     "CoinbaseDualVerification": "16.042",
-    "CoinbaseDualVerification2": "10.042",
+    "CoinbaseDualVerification2": "4.042",
     "Discord": "0.516",
     "Ens": "0.208",
     "ETHDaysActive#50": "0.207",

--- a/api/scorer/settings/gitcoin_passport_weights.py
+++ b/api/scorer/settings/gitcoin_passport_weights.py
@@ -10,7 +10,7 @@ GITCOIN_PASSPORT_WEIGHTS = {
     "CivicLivenessPass": "3.038",
     "CivicUniquenessPass": "5.005",
     "CoinbaseDualVerification": "16.042",
-    "CoinbaseDualVerification2": "10.042",
+    "CoinbaseDualVerification2": "4.042",
     "Discord": "0.516",
     "Ens": "0.208",
     "ETHDaysActive#50": "0.207",


### PR DESCRIPTION
## Description
Reintroduces the Coinbase stamp with reduced points (4.042) as requested in #3549.

### Changes
- **CoinbaseDualVerification2**: Reduced weight from `10.042` to `4.042` points

### Implementation Status
✅ Coinbase stamp code is already implemented and ready
✅ Weight updated in configuration files
⏳ Feature flag needs to be enabled: `NEXT_PUBLIC_FF_COINBASE_STAMP=on`

Closes [#3549](https://github.com/passportxyz/passport/issues/3549)