### PR TITLE
fix(ci): prevent deploy approval gate from being skipped when build_rust_scorer is false

### DIFF
--- a/.github/workflows/build_and_deploy_generic.yml
+++ b/.github/workflows/build_and_deploy_generic.yml
@@ -375,6 +375,7 @@ jobs:
   deploy_confirm:
     name: Review Approval Pending
     needs: [check_migrations, deploy_preview]
+    if: ${{ !cancelled() && !failure() }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     steps:


### PR DESCRIPTION
When build_rust_scorer is false, the implicit `if: success()` causes deploy_confirm to be skipped because its transitive dependency build-rust-scorer is skipped. Override with `!cancelled() && !failure()` so the approval gate always runs unless something actually failed.

Closes #929